### PR TITLE
Custom model pathes

### DIFF
--- a/src/cern/cpymad/listModels.py
+++ b/src/cern/cpymad/listModels.py
@@ -1,14 +1,14 @@
 #-------------------------------------------------------------------------------
 # This file is part of PyMad.
-# 
+#
 # Copyright (c) 2011, CERN. All rights reserved.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 # 	http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,24 +19,33 @@ import os,json
 from cern.pymad.globals import USE_COUCH
 import cern.cpymad
 
+modelpathes = [os.path.join(os.path.dirname(__file__),'_models')]
+
 def modelList():
     return _get_mnames_files()[0]
 
 def _get_mnames_files():
+    """List availabel models and corresponding file pathes.
+
+    Searches for all .cpymad.json files within all `modelpathes` folders.
+    Returns a list [model names] and a dictionary {file => [model names]}.
+    No care is taken to prevent a model from being listed multiple times.
+    """
     if USE_COUCH:
         return cern.cpymad._couch_server.ls_models()
-    pymadloc=os.path.dirname(__file__)
-    modelloc=os.path.join(pymadloc,'_models')
     mnames=[]
     fnames={}
-    for f in os.listdir(modelloc):
-        if len(f)>5 and f[-12:].lower()=='.cpymad.json':
-            fnames[f]=[]
-            jloaded=json.load(file(os.path.join(modelloc,f)))
+    for modelloc in modelpathes:
+        for f in os.listdir(modelloc):
+            if not f.lower().endswith('.cpymad.json'):
+                continue
+            path = os.path.join(modelloc, f)
+            fnames[path]=[]
+            jloaded=json.load(file(path))
             for mname in jloaded.keys():
                 if jloaded[mname]['real']:
                     mnames.append(mname)
-                    fnames[f].append(mname)
+                    fnames[path].append(mname)
     return mnames,fnames
 
 

--- a/src/cern/cpymad/model.py
+++ b/src/cern/cpymad/model.py
@@ -1,14 +1,14 @@
 #-------------------------------------------------------------------------------
 # This file is part of PyMad.
-# 
+#
 # Copyright (c) 2011, CERN. All rights reserved.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 # 	http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -38,21 +38,23 @@ class model(abc.model.PyMadModel):
     '''
     model class implementation. the model spawns a madx instance in a separate process.
     this has the advantage that you can run separate models which do not affect each other.
-     
+
     :param string model: Name of model to load.
     :param string optics: Name of optics to load, string or list of strings.
     :param string histfile: Name of file which will contain all Mad-X commands called.
     '''
     def __init__(self,model,sequence='',optics='',histfile='',recursive_history=False):
-        
+
         if model not in cern.cpymad.modelList():
             raise ValueError("The model you asked for does not exist in the database")
         # name of model:
         self.model=model
+        # path where the model file is located
+        self._path = os.path.dirname(_get_filename(model))
         # loading the dictionary...
         self._mdef=_get_mdef(model)
-        
-        
+
+
         # Defining two pipes which are used for communicating...
         _child_pipe_recv,_parent_send=multiprocessing.Pipe(False)
         _parent_recv,_child_pipe_send=multiprocessing.Pipe(False)
@@ -66,27 +68,27 @@ class model(abc.model.PyMadModel):
                     break
         #if self._db==None:
             #raise ValueError("It is not possible to find database directory for this model")
-        
+
         self._mprocess=_modelProcess(_child_pipe_send,_child_pipe_recv,model,histfile,recursive_history)
-        
+
         self._mprocess.start()
-        
+
         atexit.register(self._mprocess.terminate)
-        
+
         self._active={'optic':'','sequence':'','range':''}
-        
+
         self._setup_initial(sequence,optics)
-    
+
     # API stuff:
     @property
     def name(self):
         return self.model
-    
+
     @property
     def mdef(self):
         return self._mdef.copy()
-        
-    
+
+
     def set_sequence(self,sequence='',madrange=''):
         '''
         Set a new active sequence...
@@ -119,7 +121,7 @@ class model(abc.model.PyMadModel):
         else:
             if not self._active['range']:
                 self._active['range']=seqdict['default-range']
-        
+
     def _setup_initial(self,sequence,optics):
         '''
         Initial setup of the model
@@ -128,7 +130,7 @@ class model(abc.model.PyMadModel):
             if sys.flags.debug:
                 print("Calling file: "+str(ifile))
             self._call(ifile)
-        
+
         # initialize all sequences..
         for seq in self._mdef['sequences']:
             self._init_sequence(seq)
@@ -145,7 +147,7 @@ class model(abc.model.PyMadModel):
         for seq in self.get_sequences():
             self._apercalled[seq]=False
             self._twisscalled[seq]=False
-        
+
     def _init_sequence(self,sequence):
         '''
         Initialize sequence
@@ -153,18 +155,18 @@ class model(abc.model.PyMadModel):
         bname=self._mdef['sequences'][sequence]['beam']
         bdict=self.get_beam(bname)
         self.set_beam(bdict)
-    
+
     def get_beam(self,bname):
         '''
          Returns the beam definition in form
          of a dictionary.
-         
+
          You can then change parameters in this dictionary
          as you see fit, and use set_beam() to activate that
          beam.
         '''
         return self._mdef['beams'][bname]
-        
+
     def set_beam(self,beam_dict):
         '''
          Set the beam from a beam definition
@@ -176,18 +178,18 @@ class model(abc.model.PyMadModel):
         if sys.flags.debug:
             print("Beam command: "+bcmd)
         self._cmd(bcmd)
-        
-        
+
+
     def __del__(self):
         try:
             self._send('delete_model')
             self._mprocess.join(5)
         except TypeError: pass
         except AttributeError: pass
-    
+
     def __str__(self):
         return self.model
-    
+
     def _get_file_path(self,fdict):
         if 'location' in fdict:
             loc=fdict['location']
@@ -197,24 +199,24 @@ class model(abc.model.PyMadModel):
             fname = self._mdef["path-offsets"]['resource-offset']+'/'
         elif loc=='REPOSITORY':
             fname = self._mdef["path-offsets"]['repository-offset']+'/'
-        
+
         if USE_COUCH:
             raise TypeError("Sorry, couch not implemented to use this feature")
         else:
             if loc=='RESOURCE':
-                return os.path.dirname(__file__)+'/_models/resdata/'+fname
+                return self._path+'/resdata/'+fname
             elif loc=='REPOSITORY':
                 if self._db:
                     return self._db+fname
                 else:
-                    return os.path.dirname(__file__)+'/_models/repdata/'+fname
-    
+                    return self._path+'/repdata/'+fname
+
     def _call(self,fdict):
-            
+
         fpath=self._get_file_path(fdict)+fdict['path']
         self.call(fpath)
-    
-    
+
+
     def call(self,filepath):
         '''
          Call a file in Mad-X. Give either
@@ -222,82 +224,82 @@ class model(abc.model.PyMadModel):
         '''
         if not os.path.isfile(filepath):
             raise ValueError("You tried to call a file that doesn't exist: "+filepath)
-        
+
         if sys.flags.debug:
             print("Calling file: "+filepath)
-        
+
         return self._sendrecv(('call',filepath))
-    
+
     def has_sequence(self,sequence):
         '''
          Check if model has the sequence.
-         
+
          :param string sequence: Sequence name to be checked.
         '''
         return sequence in self.get_sequences()
-    
+
     def has_optics(self,optics):
         '''
          Check if model has the optics.
-         
+
          :param string optics: Optics name to be checked.
         '''
         return optics in self._mdef['optics']
-    
+
     def set_optic(self,optic):
         '''
          Set new optics.
-         
+
          :param string optics: Optics name.
-         
+
          :raises KeyError: In case you try to set an optics not available in model.
         '''
-        
+
         if optic=='':
             optic=self._mdef['default-optic']
         if self._active['optic']==optic:
             print("INFO: Optics already initialized")
             return 0
-        
+
         # optics dictionary..
         odict=self._mdef['optics'][optic]
-        
+
         for strfile in odict['init-files']:
             self._call(strfile)
-        
+
         # knobs dictionary.. we don't have that yet..
         #for f in odict['knobs']:
             #if odict['knobs'][f]:
                 #self.set_knob(f,1.0)
             #else:
                 #self.set_knob(f,0.0)
-        
+
         self._active['optic']=optic
-    
+
     def set_knob(self,knob,value):
         kdict=self._mdef['knobs']
         for e in kdict[knob]:
             val=str(kdict[knob][e]*value)
             self._cmd(e+"="+val)
-    
+
     def get_sequences(self):
         '''
          Returns a list of loaded sequences.
         '''
         return self._sendrecv('get_sequences')
-    
+
     def list_optics(self):
         '''
          Returns a list of available optics
         '''
         return self._mdef['optics'].keys()
-    
+
     def list_ranges(self,sequence=None):
         '''
          Returns a list of available ranges for the sequence.
          If sequence is not given, returns a dictionary structured as
          {sequence1:[range1,range2,...],sequence2:...}
-         
+
          :param string sequence: sequence name.
         '''
         if sequence==None:
@@ -305,15 +307,15 @@ class model(abc.model.PyMadModel):
             for s in self.get_sequences():
                 ret[s]=self._mdef['sequences'][s]['ranges'].keys()
             return ret
-        
+
         return self._mdef['sequences'][sequence]['ranges'].keys()
-    
+
     def list_beams(self):
         '''
          Returns a list of available beams
         '''
         return self._mdef['beams'].keys()
-        
+
     def _get_twiss_initial(self,sequence='',madrange='',name=''):
         '''
         Returns the dictionary for the twiss initial conditions.
@@ -340,10 +342,10 @@ class model(abc.model.PyMadModel):
               ):
         '''
          Run a TWISS on the model.
-         
+
          Warning for ranges: Currently TWISS with initial conditions is NOT
          implemented!
-         
+
          :param string sequence: Sequence, if empty, using active sequence.
          :param string columns: Columns in the twiss table, can also be list of strings
          :param string madrange: Optional, give name of a range defined for the model.
@@ -352,7 +354,7 @@ class model(abc.model.PyMadModel):
          :param bool use: Call use before twiss.
         '''
         from cern.pymad.domain import TfsTable, TfsSummary
-        
+
         # set sequence/range...
         if madrange:
             self.set_sequence(sequence,madrange)
@@ -363,10 +365,10 @@ class model(abc.model.PyMadModel):
 
         if self._apercalled[sequence]:
             raise ValueError("BUG in Mad-X: Cannot call twiss after aperture..")
-        
+
         seqdict=self._mdef['sequences'][sequence]
         rangedict=seqdict['ranges'][_madrange]
-        
+
         args={'sequence':sequence,'columns':columns,'pattern':pattern,'fname':fname,'use':use}
         args['madrange']=[rangedict["madx-range"]["first"],rangedict["madx-range"]["last"]]
         args['twiss-init']=None
@@ -376,14 +378,14 @@ class model(abc.model.PyMadModel):
                 if value:
                     args['twiss-init'][condition]=value
         t,s=self._sendrecv(('twiss',args))
-        # we say that when the "full" range has been selected, 
+        # we say that when the "full" range has been selected,
         # we can set this to true. Needed for e.g. aperture calls
         if not madrange:
             self._twisscalled[sequence]=True
         if retdict:
             return t,s
         return TfsTable(t),TfsSummary(s)
-    
+
     def survey(self,
                sequence='',
                columns='name,l,s,angle,x,y,z,theta',
@@ -393,7 +395,7 @@ class model(abc.model.PyMadModel):
                use=True):
         '''
          Run a survey on the model.
-         
+
          :param string sequence: Sequence, if empty, using active sequence.
          :param string columns: Columns in the twiss table, can also be list of strings
          :param string fname: Optionally, give name of file for tfs table.
@@ -402,12 +404,12 @@ class model(abc.model.PyMadModel):
         '''
         self.set_sequence(sequence)
         sequence=self._active['sequence']
-        
+
         this_range=''
         if madrange:
             rangedict=self._get_range_dict(sequence=sequence,madrange=madrange)
             this_range=rangedict['madx-range']
-        
+
         args={'sequence':sequence,
               'columns':columns,
               'madrange':this_range,
@@ -418,7 +420,7 @@ class model(abc.model.PyMadModel):
             return t,s
         from cern.pymad.domain import TfsTable, TfsSummary
         return TfsTable(t),TfsSummary(s)
-    
+
     def aperture(self,
                sequence='',
                madrange='',
@@ -428,7 +430,7 @@ class model(abc.model.PyMadModel):
                use=False):
         '''
          Get the aperture from the model.
-         
+
          :param string sequence: Sequence, if empty, using active sequence.
          :param string madrange: Range, if empty, the full sequence is chosen.
          :param string columns: Columns in the twiss table, can also be list of strings
@@ -439,7 +441,7 @@ class model(abc.model.PyMadModel):
         from cern.pymad.domain import TfsTable, TfsSummary
         self.set_sequence(sequence)
         sequence=self._active['sequence']
-        
+
         if not self._twisscalled[sequence]:
             self.twiss(sequence)
         # Calling "basic aperture files"
@@ -469,7 +471,7 @@ class model(abc.model.PyMadModel):
                     offsets=offsets_tmp
                 else:
                     offsets=self._get_file_path(offsets)+offsets['path']
-        
+
         args={'sequence':sequence,
               'madrange':this_range,
               'columns':columns,
@@ -482,10 +484,10 @@ class model(abc.model.PyMadModel):
         if retdict:
             return t,s
         return TfsTable(t),TfsSummary(s)
-        
+
     def _get_ranges(self,sequence):
         return self._mdef['sequences'][sequence]['ranges'].keys()
-    
+
     def _get_range_dict(self,sequence='',madrange=''):
         '''
         Returns the range dictionary. If sequence/range isn't given,
@@ -509,15 +511,14 @@ class model(abc.model.PyMadModel):
             print("Sending function call "+str(func))
         self._send(func)
         return self._recv()
-        
-           
+
+
 def _get_mdef(modelname):
     if USE_COUCH:
         return cern.cpymad._couch_server.get_model(modelname)
-        
+
     fname=_get_filename(modelname)
-    _dict = _get_file_content(modelname,fname)
-    _jdict=json.loads(_dict)
+    _jdict=json.loads(_get_file_content(modelname,fname))
     ret_dict=_jdict[modelname]
     for extra_dict in ret_dict['extends']:
         for key in _jdict[extra_dict]:
@@ -543,14 +544,20 @@ def _get_filename(modelname):
 def _get_file_content(modelname,filename):
     if USE_COUCH:
         return cern.cpymad._couch_server.get_file(modelname,filename)
-    filename=os.path.join('_models',filename)
+
     try:
-         import pkgutil
-         stream = pkgutil.get_data(__name__, filename)
-    except ImportError:
-        import pkg_resources
-        stream = pkg_resources.resource_string(__name__, filename)
-    return stream
+        with open(filename) as f:
+            data = f.read()
+    except FileNotFoundError:
+        filename = os.path.join('_models',os.path.basename(filename))
+        try:
+            import pkgutil
+            data = pkgutil.get_data(__name__, filename)
+        except ImportError:
+            import pkg_resources
+            data = pkg_resources.resource_string(__name__, filename)
+    return data
+
 
 def save_model(model_def,filename):
     '''
@@ -574,8 +581,8 @@ class _modelProcess(multiprocessing.Process):
         self.model=model
         self.history=history
         self.recursive_history=recursive_history
-        multiprocessing.Process.__init__(self) 
-    
+        multiprocessing.Process.__init__(self)
+
     def run(self):
         _madx=madx(histfile=self.history,recursive_history=self.recursive_history)
         _madx.verbose(False)


### PR DESCRIPTION
Hey,
I have performed some minor changes, so models can be loaded from any path - not just from the install path of pymad, like this:

```
# search models also in 'models' subdirectory of current directory:
cpymad.listModels.modelpathes.append(os.path.join('.', 'models'))
```

It seems to be working fine. On the other hand, I don't know for what `pkgutil.get_data` and `pkg_resources.resource_string` were used in `cern.cpymad.model._get_file_content()` - so there might be a bit of an redundancy or inconsistency now.

Tell me what you think about this.

Best regards,
Thomas
