### PR TITLE
Fix tests failing on python26 tests.

### DIFF
--- a/test/cpymadtest/test_resource.py
+++ b/test/cpymadtest/test_resource.py
@@ -169,15 +169,15 @@ class TestEggResource(Common, unittest.TestCase):
         super(TestEggResource, self).setUp()
         cwd = os.getcwd()
         os.chdir(self.base)
-        with captured_output('stdout'), captured_output('stderr'):
-            setuptools.setup(
+        with captured_output('stdout'):
+            with captured_output('stderr'):
+                setuptools.setup(
                     name=self.mod,
                     packages=[self.mod],
                     script_args=['bdist_egg', '--quiet'],
                     package_data={self.mod:[
                         'a.json',
-                        os.path.join('subdir', 'b.json')]}
-                    )
+                        os.path.join('subdir', 'b.json')]})
         os.chdir(cwd)
         self.eggs = os.listdir(os.path.join(self.base, 'dist'))
         for egg in self.eggs:


### PR DESCRIPTION
I got notified about two failing tests in the CDash environment.

This should fix [the error in `test_resource`](http://abp-cdash.web.cern.ch/abp-cdash/testDetails.php?test=19873&build=8590).

I don't see why [the error in `test_madx`](http://abp-cdash.web.cern.ch/abp-cdash/testDetails.php?test=19872&build=8590) emerges. I would guess that the `madx.pyx` has not been recompiled before issueing the test. Maybe the test configuration does not enforce automatic rebuild?

By the way: does the current automated test only test on python26? I think this is insufficient, as there are quite some differences in python27 and especially on python3 which I'd like to migrate to later on. Is there any way to test multiple python versions with CDash?
