### PR TITLE
Test a previously uncovered scenario

### DIFF
--- a/test/cpymadtest/test_resource.py
+++ b/test/cpymadtest/test_resource.py
@@ -191,6 +191,15 @@ class TestEggResource(Common, unittest.TestCase):
             sys.path.remove(os.path.join(self.base, 'dist', egg))
         super(TestEggResource, self).tearDown()
 
+    def test_is_valid(self):
+        """
+        Check that the test uses a .egg resource.
+
+        Only then the test results confirm that the package is working.
+
+        """
+        self.assertTrue(self.res._is_extracted)
+
     def test_filename(self):
         with self.res.filename('a.json') as filename:
             with open(filename, encoding='utf-8') as f:
@@ -212,6 +221,17 @@ class TestEggResource(Common, unittest.TestCase):
                         json.loads(f.read())['path'],
                         'subdir/b.json')
         self.assertFalse(os.path.exists(filename))
+
+    def test_use_filename_twice(self):
+        with self.res.filename('a.json') as filename:
+            self.assertTrue(os.path.exists(filename))
+        self.assertFalse(os.path.exists(filename))
+        with self.res.filename('a.json') as filename:
+            self.assertTrue(os.path.exists(filename))
+            with open(filename, encoding='utf-8') as f:
+                self.assertEqual(
+                        json.loads(f.read())['path'],
+                        'a.json')
 
 class TestFileResource(Common, unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
The added test checks that the `PackageResource.filename()` method is
working as expected when called multiple times (subsequently).

**TODO:**

There is one more uncovered case that will misbehave with the current
implementation:

``` python
with res.filename() as f1:
    with res.filename() as f2:
        assert(f1 == f2)    # True
    assert(os.exists(f1))   # False (as an unpleasant consequence)
    # will probably raise exception at this point (when exiting the
    # context manager)
```

The easiest fix for this problem is to drop the cleanup of the file in
the **exit** method. Another possibility might be a reference count. Not
sure how to do this, though.

There is another reason to remove the cleanup code: When calling
pkg_resources.get_resource_filename() the requested resource might not
be the only resource that is extracted at this point,
[c.f.](http://pythonhosted.org/setuptools/pkg_resources.html#resource-extraction):

```
If the named resource is a directory, then all resources within that
directory (including subdirectories) are also extracted. If the
named resource is a C extension or “eager resource” (see the
setuptools documentation for details), then all C extensions and
eager resources are extracted at the same time.
```

Apparently, pkg_resources uses
[`tempfile.mkstemp`](http://docs.python.org/3.3/library/tempfile.html#tempfile.mkstemp)
to create a temporary file. If there are _useful_ guarantees about the
life time of this temporary file, removing the cleanup clause should
definitely be considered. I will try to find out if this requirement is
satisfied.
