### PR TITLE
Hotfix for MAD-X installation on Travis

### DIFF
--- a/.madx_install_header.patch
+++ b/.madx_install_header.patch
@@ -1,0 +1,17 @@
+Index: cmake/install_macros.cmake
+===================================================================
+--- cmake/install_macros.cmake	(revisjon 4064)
++++ cmake/install_macros.cmake	(arbeidskopi)
+@@ -17,9 +17,9 @@
+ macro(madx_install_headers)
+     # This installs the header files to <prefix>/include/madX
+     # We only want this in the development version...
+-    if(NOT ${MADX_PATCH_LEVEL} EQUAL 00)
++    if(NOT ${BINARY_POSTFIX} STREQUAL "")
+         install(FILES ${ARGN} 
+                 DESTINATION "include/${PROJECT_NAME}"
+                 COMPONENT Files)
+     endif()
+-endmacro()
+\ No newline at end of file
++endmacro()

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ before_install:
   # Build MAD-X (takes a lot of time - should use a binary distribution):
   - svn co http://svnweb.cern.ch/guest/madx/trunk/madX
   - cd madX
+  - patch -p0 -i ../.madx_install_header.patch
   - cmake -DCMAKE_C_COMPILER=gcc
           -DCMAKE_Fortran_COMPILER=gfortran
           -DMADX_STATIC=OFF


### PR DESCRIPTION
For whatever reason, the headers are only part of the installation if the patch level differs from MADX_PATCH_LEVEL=00. I guess, with the new release number this makes problems(?). The fix is copied from the AUR package.

Note that this effects only the Travis build and doesn't need to be tested in the `testing` branch. If you agree, I merge this ASAP, since it's needed for other branches as well.
