### PR TITLE
Remove the "sanity-checks" from Madx.command?

### DIFF
--- a/src/cern/cpymad/madx.py
+++ b/src/cern/cpymad/madx.py
@@ -158,20 +158,7 @@ class Madx(object):
         :param str cmd: command name
         :param **kwargs: command parameters
         """
-        return MadxCommands(self._check_command)
-
-    def _check_command(self, cmd):
-        """Execute command after performing some sanity checks."""
-        if cmd.lower() in ('stop;', 'exit;'):
-            print("WARNING: found quit in command: "+cmd+"\n")
-            print("Please use madx.finish() or just exit python (CTRL+D)")
-            print("Command ignored")
-            return
-        if cmd.lower().startswith('plot'):
-            print("WARNING: Plot functionality does not work through pymadx")
-            print("Command ignored")
-            return
-        self.input(cmd)
+        return MadxCommands(self.input)
 
     def input(self, text):
         """


### PR DESCRIPTION
`Madx.command` can not veto automatically executed commands from CALLed files. It only gets invoked for commands that the user has explicitly typed or were written in the program. IMO, it should be exactly the other way round: prevent automatically loaded commands, but allow the user to do anything (let the user try and the program fail, if it so will).

Therefore, I'd suggest to strip this feature.
