### PR TITLE
Remove recursive_history feature

### DIFF
--- a/src/cern/cpymad/madx.py
+++ b/src/cern/cpymad/madx.py
@@ -122,17 +122,13 @@ class Madx(object):
     '''
     Python class which interfaces to Mad-X library
     '''
-    _hist = False
     _hfile = None
-    _rechist = False
 
-    def __init__(self, histfile=None, recursive_history=False, libmadx=None):
+    def __init__(self, histfile=None, libmadx=None):
         '''
         Initializing Mad-X instance
 
         :param str histfile: (optional) name of file which will contain all Mad-X commands.
-        :param bool recursive_history: If true, history file will contain no calls to other files.
-                                       Instead, recursively writing commands from these files when called.
         :param object libmadx: :mod:`libmadx` compatible object
 
         '''
@@ -141,9 +137,7 @@ class Madx(object):
             self._libmadx.start()
 
         if histfile:
-            self._hist = True
             self._hfile = open(histfile,'w')
-            self._rechist = recursive_history
 
     def __del__(self):
         """Close history file."""
@@ -389,16 +383,7 @@ class Madx(object):
 
     def _writeHist(self,command):
         # this still brakes for "multiline commands"...
-        if not self._hfile:
-            return
-        if self._rechist and command.split(',')[0].strip().lower()=='call':
-            cfile=command.split(',')[1].strip().strip('file=').strip('FILE=').strip(';\n').strip('"').strip("'")
-            if sys.flags.debug:
-                print("DBG: call file ",cfile)
-            fin=open(cfile,'r')
-            for l in fin:
-                self._writeHist(l+'\n')
-        else:
+        if self._hfile:
             self._hfile.write(command)
             self._hfile.flush()
 

--- a/src/cern/cpymad/model.py
+++ b/src/cern/cpymad/model.py
@@ -67,7 +67,7 @@ class Model(abc.model.PyMadModel):
 
     def __init__(self, model,
                  sequence='',optics='',
-                 histfile='',recursive_history=False,
+                 histfile='',
                  madx=None):
         """
         Construct a Model object.
@@ -76,14 +76,13 @@ class Model(abc.model.PyMadModel):
         :param string sequence: Name of the default sequence to use
         :param string optics: Name of optics to load, string or list of strings.
         :param string histfile: Name of file which will contain all Mad-X commands called.
-        :param bool recursive_history: Recursively load commands of called files into histfile
 
         For backward compatibility reasons, the first parameter can also be
         the name of the model to be loaded. This is equivalent to the
         preferred Model.from_name() constructor.
 
         """
-        self._madx = madx or Madx(histfile, recursive_history)
+        self._madx = madx or Madx(histfile)
         self._madx.verbose(False)
 
         if isinstance(model, ModelData):


### PR DESCRIPTION
I don't believe the feature is very useful. It just adds a
hard-to-understand parameter to the constructor of the Madx/Model classes.

The recursive_history mode makes it impossible to distinguish between
commands created by PyMAD and commands contained in a CALLed file.

Furthermore, the implementation is probably still incorrect for many edge
cases like multiline commands.
