### PR TITLE
Remove file-name completion in Madx.call

### DIFF
--- a/src/cern/cpymad/madx.py
+++ b/src/cern/cpymad/madx.py
@@ -214,20 +214,12 @@ class Madx(object):
         :param str filename: file name with path
         :param bool chdir: temporarily change directory in MAD-X process
         """
-        fname=filename
-        if not os.path.isfile(fname):
-            fname=filename+'.madx'
-        if not os.path.isfile(fname):
-            fname=filename+'.mad'
-        if not os.path.isfile(fname):
-            print("ERROR: "+filename+" not found")
-            return 1
         if chdir:
-            dirname, basename = os.path.split(fname)
+            dirname, basename = os.path.split(filename)
             with self.chdir(dirname):
                 self.command.call(file=basename)
         else:
-            self.command.call(file=fname)
+            self.command.call(file=filename)
 
     def select(self, flag, columns, pattern=[]):
         """


### PR DESCRIPTION
IMO, files should always be specified by their full name. Trying to guess a
different name should not be the responsibility of pymad. For example, the
current implementation doesn't care if there are .str and .madx files with
the same base name, which can lead to indeterministic program behaviour -
consider the following case:
- call('some-file')  ->  calls some-file.str
- some-file.madx is added on the file-system
- call('some-file')  ->  calls some-file.madx
