### PR TITLE
retrieve MAD-X version

### DIFF
--- a/src/cern/cpymad/clibmadx.pxd
+++ b/src/cern/cpymad/clibmadx.pxd
@@ -35,6 +35,10 @@ cdef extern from "madX/mad_def.h":
     enum:
         NAME_L
 
+cdef extern from "madX/mad_gcst.h":
+    char* version_name
+    char* version_date_mod
+
 cdef extern from "madX/mad_array.h":
     struct char_array:
         int curr

--- a/src/cern/cpymad/clibmadx.pxd
+++ b/src/cern/cpymad/clibmadx.pxd
@@ -38,7 +38,7 @@ cdef extern from "madX/mad_def.h":
 cdef extern from "madX/mad_gcst.h":
     # NOTE: C API uses "const char*"
     char* version_name
-    char* version_date_mod
+    char* version_date
 
 cdef extern from "madX/mad_array.h":
     struct char_array:

--- a/src/cern/cpymad/clibmadx.pxd
+++ b/src/cern/cpymad/clibmadx.pxd
@@ -36,6 +36,7 @@ cdef extern from "madX/mad_def.h":
         NAME_L
 
 cdef extern from "madX/mad_gcst.h":
+    # NOTE: C API uses "const char*"
     char* version_name
     char* version_date_mod
 

--- a/src/cern/cpymad/libmadx.pyx
+++ b/src/cern/cpymad/libmadx.pyx
@@ -64,8 +64,8 @@ def _get_rightmost_word(sentence):
 
 
 # MAD-X version introspection
-madx_release = _get_right_word(_str(clib.version_name))
-madx_date = _get_right_word(_str(clib.version_date_mod))
+madx_release = _get_rightmost_word(_str(clib.version_name))
+madx_date = _get_rightmost_word(_str(clib.version_date_mod))
 
 
 def started():

--- a/src/cern/cpymad/libmadx.pyx
+++ b/src/cern/cpymad/libmadx.pyx
@@ -65,7 +65,7 @@ def _get_rightmost_word(sentence):
 
 # MAD-X version introspection
 madx_release = _get_rightmost_word(_str(clib.version_name))
-madx_date = _get_rightmost_word(_str(clib.version_date_mod))
+madx_date = _get_rightmost_word(_str(clib.version_date))
 
 
 def started():

--- a/src/cern/cpymad/libmadx.pyx
+++ b/src/cern/cpymad/libmadx.pyx
@@ -32,6 +32,8 @@ _madx_started = False
 
 # Python-level binding to libmadx:
 __all__ = [
+    'madx_version',
+    'madx_date',
     'started',
     'start',
     'finish',
@@ -54,6 +56,16 @@ __all__ = [
     'chdir',
     'getcwd',
 ]
+
+
+def _get_rightmost_word(sentence):
+    """Get the work right of the rightmost space character."""
+    return sentence.rsplit(' ', 1)[-1]
+
+
+# MAD-X version introspection
+madx_version = _get_right_word(_str(clib.version_name))
+madx_date = _get_right_word(_str(clib.version_date_mod))
 
 
 def started():

--- a/src/cern/cpymad/libmadx.pyx
+++ b/src/cern/cpymad/libmadx.pyx
@@ -32,7 +32,7 @@ _madx_started = False
 
 # Python-level binding to libmadx:
 __all__ = [
-    'madx_version',
+    'madx_release',
     'madx_date',
     'started',
     'start',
@@ -64,7 +64,7 @@ def _get_rightmost_word(sentence):
 
 
 # MAD-X version introspection
-madx_version = _get_right_word(_str(clib.version_name))
+madx_release = _get_right_word(_str(clib.version_name))
 madx_date = _get_right_word(_str(clib.version_date_mod))
 
 

--- a/src/cern/cpymad/madx.py
+++ b/src/cern/cpymad/madx.py
@@ -59,6 +59,16 @@ except NameError:
     basestring = str
 
 
+class Version(object):
+
+    """Version information struct. """
+
+    def __init__(self, release, date):
+        """Store version information."""
+        self.release = release
+        self.date = date
+
+
 class ChangeDirectory(object):
 
     """Context manager for temporarily changing current working directory."""
@@ -143,6 +153,14 @@ class Madx(object):
         """Close history file."""
         if self._hfile:
             self._hfile.close()
+
+    @property
+    def version(self):
+        """
+        Get the MAD-X version.
+        """
+        return Version(self._libmadx.madx_release,
+                       self._libmadx.madx_date)
 
     @property
     def command(self):


### PR DESCRIPTION
I think there should be a way to retrieve the MAD-X version programmatically. If possible the revision number would be even better.
