### PR TITLE
Allow multi-index access in TableColumns

### DIFF
--- a/src/cern/cpymad/madx.py
+++ b/src/cern/cpymad/madx.py
@@ -559,17 +559,22 @@ class TableColumns(object):
 
     def __getattr__(self, column):
         """Get the column data."""
-        try:
-            return self._libmadx.get_table_column(self._table, column.lower())
-        except ValueError:
-            raise AttributeError(column)
+        return self[column]
 
     def __getitem__(self, column):
         """Get the column data."""
-        try:
-            return self._libmadx.get_table_column(self._table, column.lower())
-        except ValueError:
-            raise KeyError(column)
+        if isinstance(column, basestring):
+            try:
+                return self._libmadx.get_table_column(
+                    self._table,
+                    column.lower())
+            except ValueError:
+                raise KeyError(column)
+        elif isinstance(column, collections.Sequence):
+            return column.__class__(self[col] for col in column)
+        else:
+            raise TypeError("Invalid argument type: {0}"
+                            .format(column.__class__.__name__))
 
     def __iter__(self):
         """Get a list of all column names."""


### PR DESCRIPTION
Allows access like:

```
betx, bety = table['betx', 'bety']
```
