### PR TITLE
Add MAD-X license information

### DIFF
--- a/COPYING.rst
+++ b/COPYING.rst
@@ -1,0 +1,133 @@
+License
+~~~~~~~
+
+cern-cpymad must be used in compliance with the licenses as described in
+the following sections:
+
+
+License for cern-cpymad source
+==============================
+
+applies to the python source of the cern-cpymad package::
+
+    Copyright (c) 2011, CERN. All rights reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use cern-cpymad except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+
+License for MAD-X
+=================
+
+applies to binary distributions that do not require a separate
+installation of MAD-X, i.e. binaries that are statically linked to MAD-X::
+
+    CERN
+
+    EUROPEAN ORGANISATION FOR NUCLEAR RESEARCH
+
+
+    Program name:                 MAD --- Methodical Accelerator Design
+
+    CERN program library entry:   T5001
+
+    Authors or contacts:          mad@cern.ch
+                                  BE-ABP Group
+                                  CERN
+                                  CH-1211 GENEVA 23
+                                  SWITZERLAND
+
+
+    Copyright CERN, Geneva 1990 - Copyright and any other appropriate legal
+    protection of this computer program and associated documentation reserved
+    in all countries of the world. Organisations collaborating with CERN may
+    receive this program and documentation freely and without charge. CERN
+    undertakes no obligation for the maintenance of this program, nor
+    responsibility for its correctness, and accepts no liability whatsoever
+    resulting from its use. Program and documentation are provided solely for
+    the use of the organisation to which they are distributed. This program
+    may not be copied or otherwise distributed without permission. This
+    message must be retained on this and any other authorised copies. The
+    material cannot be sold. CERN should be given credit in all references.
+
+
+Additional SDDS License
+=======================
+
+applies to binary distributions that include the online model::
+
+    Copyright (c) 2002 University of Chicago. All rights reserved.
+
+    SDDS ToolKit is distributed subject to the following license conditions:
+
+     SOFTWARE LICENSE AGREEMENT
+     Software: SDDS ToolKit
+
+     1. The "Software", below, refers to SDDS ToolKit (in either source code,
+        or binary form and accompanying documentation). Each licensee is
+        addressed as "you" or "Licensee."
+
+     2. The copyright holders shown above and their third-party licensors
+        hereby grant Licensee a royalty-free nonexclusive license, subject to
+        the limitations stated herein and U.S. Government license rights.
+
+     3. You may modify and make a copy or copies of the Software for use
+        within your organization, if you meet the following conditions:
+          a. Copies in source code must include the copyright notice and this
+             Software License Agreement.
+          b. Copies in binary form must include the copyright notice and this
+             Software License Agreement in the documentation and/or other
+             materials provided with the copy.
+
+     4. You may modify a copy or copies of the Software or any portion of it,
+        thus forming a work based on the Software, and distribute copies of
+        such work outside your organization, if you meet all of the following
+        conditions:
+          a. Copies in source code must include the copyright notice and this
+             Software License Agreement;
+          b. Copies in binary form must include the copyright notice and this
+             Software License Agreement in the documentation and/or other
+             materials provided with the copy;
+          c. Modified copies and works based on the Software must carry
+             prominent notices stating that you changed specified portions of
+             the Software.
+
+     5. Portions of the Software resulted from work developed under a U.S.
+        Government contract and are subject to the following license: the
+        Government is granted for itself and others acting on its behalf a
+        paid-up, nonexclusive, irrevocable worldwide license in this computer
+        software to reproduce, prepare derivative works, and perform publicly
+        and display publicly.
+
+     6. WARRANTY DISCLAIMER. THE SOFTWARE IS SUPPLIED "AS IS" WITHOUT
+        WARRANTY OF ANY KIND. THE COPYRIGHT HOLDERS, THEIR THIRD PARTY
+        LICENSORS, THE UNITED STATES, THE UNITED STATES DEPARTMENT OF
+        ENERGY, AND THEIR EMPLOYEES: (1) DISCLAIM ANY WARRANTIES,
+        EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY IMPLIED
+        WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE,
+        TITLE OR NON-INFRINGEMENT, (2) DO NOT ASSUME ANY LEGAL LIABILITY
+        OR RESPONSIBILITY FOR THE ACCURACY, COMPLETENESS, OR USEFULNESS
+        OF THE SOFTWARE, (3) DO NOT REPRESENT THAT USE OF THE SOFTWARE
+        WOULD NOT INFRINGE PRIVATELY OWNED RIGHTS, (4) DO NOT WARRANT
+        THAT THE SOFTWARE WILL FUNCTION UNINTERRUPTED, THAT IT IS
+        ERROR-FREE OR THAT ANY ERRORS WILL BE CORRECTED.
+
+     7. LIMITATION OF LIABILITY. IN NO EVENT WILL THE COPYRIGHT HOLDERS,
+        THEIR THIRD PARTY LICENSORS, THE UNITED STATES, THE UNITED
+        STATES DEPARTMENT OF ENERGY, OR THEIR EMPLOYEES: BE LIABLE FOR
+        ANY INDIRECT, INCIDENTAL, CONSEQUENTIAL, SPECIAL OR PUNITIVE
+        DAMAGES OF ANY KIND OR NATURE, INCLUDING BUT NOT LIMITED TO LOSS
+        OF PROFITS OR LOSS OF DATA, FOR ANY REASON WHATSOEVER, WHETHER
+        SUCH LIABILITY IS ASSERTED ON THE BASIS OF CONTRACT, TORT
+        (INCLUDING NEGLIGENCE OR STRICT LIABILITY), OR OTHERWISE, EVEN
+        IF ANY OF SAID PARTIES HAS BEEN WARNED OF THE POSSIBILITY OF
+        SUCH LOSS OR DAMAGES.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,6 @@ recursive-include src *.pxd *.pyx *.c
 recursive-include src/cern/cpymad/_models *.yml
 recursive-include src/cern/cpymad/_models/re*data *.madx *.str *.seq *.tfs *.xsifx *CLICx *.ind92
 recursive-include test *.py *.cmake *.txt
-include README.rst CHANGES.rst LICENSE.txt
+include README.rst CHANGES.rst LICENSE.txt COPYING.txt
 include *.cmake
 include requirements.txt

--- a/README.rst
+++ b/README.rst
@@ -16,6 +16,10 @@ but does not require a C compiler for installing.
 .. _JMad: http://jmad.web.cern.ch/jmad/
 .. _JPyMAD: https://github.com/pymad/jpymad
 
+**IMPORTANT:** cern-cpymad links against an unofficial build of MAD-X that
+is not supported by CERN, i.e. in case of problems you will not get help
+there.
+
 
 Dependencies
 ------------

--- a/setup.py
+++ b/setup.py
@@ -91,6 +91,7 @@ extension_args = dict(
 long_description = None
 try:
     long_description = open('README.rst').read()
+    long_description += '\n' + open('COPYING.rst').read()
     long_description += '\n' + open('CHANGES.rst').read()
 except IOError:
     pass


### PR DESCRIPTION
In order to distribute binaries which are statically linked to MAD-X on PyPI, the MAD-X license must be made explicit for the user. For this purpose, I added a `COPYING.rst` file which explains the licenses involved in source/binary distributions.
