### PR TITLE
Use -std=c99 for Cython extension to fix compile error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,9 @@ extension_args = dict(
     libraries=libraries,
     include_dirs=include_dirs,
     library_dirs=library_dirs,
-    runtime_library_dirs=library_dirs)
+    runtime_library_dirs=library_dirs,
+    extra_compile_args=['-std=c99'],
+)
 
 # Compose a long description for PyPI:
 long_description = None


### PR DESCRIPTION
New MAD-X header files seem to require features that are only available
on C99.

Unfortunately, this fix is specific to GCC.
